### PR TITLE
Change endpoints to /oidc path

### DIFF
--- a/lib/omniauth/strategies/tara.rb
+++ b/lib/omniauth/strategies/tara.rb
@@ -21,7 +21,7 @@ module OmniAuth
         scheme: 'https',
         host: nil,
         port: 443,
-        authorization_endpoint: '/authorize',
+        authorization_endpoint: '/oidc/authorize',
         token_endpoint: '/token',
         userinfo_endpoint: '/userinfo',
         jwks_uri: '/jwk',

--- a/lib/omniauth/strategies/tara.rb
+++ b/lib/omniauth/strategies/tara.rb
@@ -22,9 +22,9 @@ module OmniAuth
         host: nil,
         port: 443,
         authorization_endpoint: '/oidc/authorize',
-        token_endpoint: '/token',
-        userinfo_endpoint: '/userinfo',
-        jwks_uri: '/jwk',
+        token_endpoint: '/oidc/token',
+        userinfo_endpoint: '/oidc/userinfo',
+        jwks_uri: '/oidc/jwk',
         end_session_endpoint: nil
       }
       option :issuer


### PR DESCRIPTION
RIA authorization endpoint has changed to `oidc/authorize` instead of just `/authorize`. This caused invalid authentications for me without any clear error.

By checking the documentation then I saw that also `token_endpoint` and `jwks_uri` endpoint changed. `userinfo_endpoint` does not seem to be in use by TARA documentation but updated it as well still.

This PR changes the upper-mentioned endpoints to include also the `/oidc` path in tara omniauth strategy.